### PR TITLE
Set correct values for YACC and LEX on Linux

### DIFF
--- a/OMakefile
+++ b/OMakefile
@@ -30,7 +30,7 @@ BuildDist() =
     rm $(filter-proper-targets $(ls R, .))
 
     mkdir dist
-    cp README dist/
+    cp README.md dist/
     cp COPYING dist/
     cp OMakefile dist/
     cp OMakeroot dist/
@@ -51,7 +51,7 @@ dist:
     section
         BuildDist()
         cd dist && omake all
-        VERSION = $(shell dist/tjcc -v | perl -pe 's/Teyjus version //')
+        VERSION = $(shell ./tjcc -v | perl -pe 's/Teyjus version //')
         BuildDist()
         rm -f dist.tar.gz
         mv dist teyjus

--- a/source/OMakefile
+++ b/source/OMakefile
@@ -187,6 +187,11 @@ PAR_MAIN = $(FNT)/parsefront
 # Platform specific changes
 #
 
+if $(mem $(SYSNAME), Linux)
+    YACC = bison -by
+    LEX = flex
+    export
+
 if $(mem $(OSTYPE), Cygwin Win32)
     YACC = bison -by
     LEX = flex


### PR DESCRIPTION
By default, omake assumes YACC = yacc and LEX = lex on Unix. For Linux, this does not work if gnu tools are used, compilation failure ensues. Hopefully fixed (I don't know much about omake)