### PR TITLE
Add string literals from proper character groups

### DIFF
--- a/source/compiler/lplex.mll
+++ b/source/compiler/lplex.mll
@@ -215,11 +215,14 @@ and stringstate = parse
 | "\\\""        {addChar '"'; stringstate lexbuf}
 | "\"\""        {addChar '"'; stringstate lexbuf}
 
-| "\\^"['@'-'z'] as text            {addControl text; stringstate lexbuf}
-| "\\" OCTAL as text                {addOctal text; stringstate lexbuf}
-| "\\" (OCTAL OCTAL OCTAL) as text  {addOctal text; stringstate lexbuf}
-| "\\x" HEX as text                 {addHex text; stringstate lexbuf}
-| "\\x" (HEX HEX) as text           {addHex text; stringstate lexbuf}
+| "\\^" (['@'-'z'] as text)         {addControl (String.make 1 text);
+                                     stringstate lexbuf}
+| "\\" (OCTAL as text)              {addOctal (String.make 1 text);
+                                     stringstate lexbuf}
+| "\\" (OCTAL OCTAL OCTAL as text)  {addOctal text; stringstate lexbuf}
+| "\\x" (HEX as text)               {addHex (String.make 1 text);
+                                     stringstate lexbuf}
+| "\\x" (HEX HEX as text)           {addHex text; stringstate lexbuf}
 
 | "\\x" _         {Errormsg.error lexbuf.lex_curr_p 
                     "Illegal hex character specification";


### PR DESCRIPTION
Escape prefixes were included in the strings being passed to the character composition functions, resulting in incorrect characters being generated (in the case of control characters) or exceptions
being thrown (in octal and hex literals, in combination with the OCaml-specific prefixes).

I tested this on a couple of machines running the latest versions of Ubuntu and Mint, with OCaml 4.02.3. In addition you may want to consider corrections to https://github.com/teyjus/teyjus/wiki/TeyjusTokens#string-literals, especially regarding formatting of control characters and the reported decimal notation.