### PR TITLE
Emacs inferior process: teyjus-inferior-mode

### DIFF
--- a/emacs/teyjus.el
+++ b/emacs/teyjus.el
@@ -2,20 +2,25 @@
 ;;;
 ;;; Teyjus Lambda Prolog mode to go with COMINT package by Kamal Aboul-Hosn
 ;;; Reduced for Teyjus 2.0 by Andrew Gacek
+;;; The Comint derived teyjus-inferior-mode added by Shon Feder
 ;;;
 ;;; This package handles the following features:
 ;;;   - Syntax highlighting for .mod and .sig files
 ;;;   - Running an inferior tjcc process within Emacs
 ;;;   - Teyjus support for emacs compilation mode (M-x compile)
 ;;;
-;;; Commands have been added to make easier the use of Teyjus:
+;;; Commands have been added to make the use of Teyjus easier:
 ;;;
-;;;  Command                Shortcut     Function
-;;;  ----------             --------     --------
-;;;  M-x teyjus-compile     C-c C-c      Compile a module
-;;;  M-x teyjus-next-error  C-c C-n      Find the next compilation error
-;;;  M-x teyjus-prev-error  C-c C-p      Find the previous compilation error
-;;;
+;;;  Command                 Shortcut     Function
+;;;  ----------              --------     --------
+;;;  M-x teyjus-compile      C-c C-c      Compile a module
+;;;  M-x teyjus-next-error   C-c C-n      Find the next compilation error
+;;;  M-x teyjus-prev-error   C-c C-p      Find the previous compilation error
+;;;  M-x teyjus-run                       Start tjsim as an inferior process
+;;;  M-x teyjus-load-buffer  C-c C-f      Save, compile, link, load current file into inferior process.
+;;;  M-x teyjus-path-add-current-buffer   Add current buffer's directory to $TJPATH, making modules available for `tjsim' and `tjlink'.
+;;;  M-x teyjus-path-add-remove-buffer    Remove current buffer's directory from $TJPATH.
+
 ;;; These commands are also available via the Teyjus menu
 ;;;
 ;;;
@@ -23,10 +28,12 @@
 ;;;
 ;;;   (load "~/teyjus/emacs/teyjus.el")
 ;;;
-;;; Adjust the path as neccesary. If tjcc is not in your $PATH then you
-;;; should set the variable tjcc to the precise location. For example,
+;;; Adjust the path as neccesary. If tjcc, tjlink, and tjsim are not in your
+;;; $PATH then you should set the variables to the precise location. For example,
 ;;;
-;;;   (setq tjcc "~/teyjus/tjcc")
+;;;   (setq tjcc   "~/teyjus/tjcc")
+;;;   (setq tjlink "~/teyjus/tjlink")
+;;;   (setq tjsim  "~/teyjus/tjsim")
 ;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -39,14 +46,40 @@
 (setq auto-mode-alist (cons '("\\.mod\\'" . teyjus-edit-mode) auto-mode-alist))
 (setq auto-mode-alist (cons '("\\.sig\\'" . teyjus-edit-mode) auto-mode-alist))
 
-(defvar tjcc "tjcc")
+(defvar tjcc "tjcc"
+  "The path to the Teyjus compiler executable.
+
+By default, it assumes the binary `tjcc' is available as a command in your $PATH.
+Otherwise, set this variable to the path where your `tjcc' is located.")
+
+(defvar tjlink "tjlink"
+  "The path to the Teyjus linker executable.
+
+By default, it assumes the binary `tjlink' is available as a command in your $PATH.
+Otherwise, set this variable to the path where your `tjlink' is located.")
+
+(defvar tjsim "tjsim"
+  "The path to the Teyjus simulator executable.
+
+By default, it assumes the binary `tjsim' is available as a command in your $PATH.
+Otherwise, set this variable to the path where your `tjsim' is located.")
+
+(defvar tjpath (if (getenv "TJPATH")
+                   (split-string  (getenv "TJPATH") ":")
+                 nil)
+  "Initialize `tjpath' with the environment variable TJPATH.
+
+`tjpath' as a list of the paths in the environment variable. This variable is used
+as intermediary for updating the $TJPATH environment variable.
+`tjpath' is initialized as an empty list, in the event that $TJPATH is not set.")
 
 (defvar teyjus-edit-mode-map nil)
 (cond ((not teyjus-edit-mode-map)
        (setq teyjus-edit-mode-map (make-sparse-keymap))
        (define-key teyjus-edit-mode-map "\C-c\C-c" 'teyjus-compile)
        (define-key teyjus-edit-mode-map "\C-c\C-p" 'teyjus-prev-error)
-       (define-key teyjus-edit-mode-map "\C-c\C-n" 'teyjus-next-error)))
+       (define-key teyjus-edit-mode-map "\C-c\C-n" 'teyjus-next-error)
+       (define-key teyjus-edit-mode-map "\C-c\C-f" 'teyjus-load-buffer)))
 
 (defvar teyjus-mode-hook '()
   "*Hook for customizing teyjus mode")
@@ -54,9 +87,16 @@
 ;; Define the menu for teyjus
 (defvar teyjus-menu
   '("Teyjus"
-    ["Compile current module"           teyjus-compile    t]
-    ["Show next compilation error"      teyjus-next-error t]
-    ["Show previous compilation error"  teyjus-prev-error t]))
+    ["Compile current module"           teyjus-compile     t]
+    ["Show next compilation error"      teyjus-next-error  t]
+    ["Show previous compilation error"  teyjus-prev-error  t]
+    ["-----" nil t]
+    ["Start simulator"                  teyjus-run-buffer  t]
+    ["Load current module in simulator" teyjus-load-buffer t]
+    ["-----" nil t]
+    ["Add buffer directory to path"       teyjus-path-add-current-buffer t]
+    ["Remove buffer directory from path"  teyjus-path-add-remove-buffer  t]
+    ))
 
 (defun teyjus-edit-mode ()
   "Mode for editing Lambda Prolog Files"
@@ -95,7 +135,7 @@
   (add-to-list 'compilation-error-regexp-alist-alist
                (list 'teyjus teyjus-error-regexp 1 2 3 '(4)))
   (add-to-list 'compilation-error-regexp-alist 'teyjus))
- 
+
  (t
   ;; emacs21
   (add-to-list 'compilation-error-regexp-alist
@@ -181,12 +221,12 @@
 
 (defvar teyjus-font-lock-keywords
   (list
-   ;; Variables   
+   ;; Variables
    (cons "\\<[A-Z][A-Za-z0-9'/]*\\>" font-lock-variable-name-face)
-         
+
    ;; Cut
    (cons "!" font-lock-warning-face)
-    
+
    ;; Headers
    (cons (make-regex "module" "sig") font-lock-function-name-face)
 
@@ -207,3 +247,176 @@
    ;; Types
    (cons (make-regex  "int" "real" "string" "list" "out_stream" "in_stream" "o")
          font-lock-type-face)))
+
+
+;; Dealing with TJPATH
+;; This code is mainly intended to circumvent difficulties relating to
+;; the inability to pass file paths to `tjsim' and `tjlink'.
+;; However, it is probably useful in its own right, as a way of
+;; loading and testing out several dependent modules.
+
+(defun teyjus-path-update ()
+  "Set the environment variable $TJPATH to the paths in `tjpath'."
+  (setenv "TJPATH" (mapconcat 'identity tjpath ":")))
+
+(defun teyjus-path-add-directory (dir)
+  "Add `dir' to `tjpath' and update $TJPATH."
+  (interactive)
+  (add-to-list 'tjpath dir 't)
+  (teyjus-path-update))
+
+(defun teyjus-path-remove-directory (dir)
+  "Remove `dir' from `tjpath' and update $TJPATH"
+  (interactive)
+  (setq tjpath (delete dir tjpath))
+  (teyjus-path-update))
+
+(defun teyjus-path-add-current-buffer ()
+  "Add directory of current buffer's file to `tjpath' and update $TJPATH"
+  (interactive)
+  (teyjus-path-add-directory (file-name-directory (buffer-file-name)))
+  (teyjus-path-update))
+
+(defun teyjus-path-remove-current-buffer ()
+  "Remove directory of current buffer's file from `tjpath', update $TJPATH"
+  (interactive)
+  (teyjus-path-remove-directory (file-name-directory (buffer-file-name)))
+  (teyjus-path-update))
+
+;; teyjus-inferior-mode
+;; Implemented with reference to
+;; https://www.masteringemacs.org/article/comint-writing-command-interpreter
+
+
+;; General utility functions
+;;
+
+(defun get-buffer-size (buffer-name)
+  "get-buffer-size: string -> int
+
+Given a string naming a buffer, buffer-name it returns the value of
+(buffer-size (get-buffer buffer-name)) if there is a buffer by that name
+or else 0."
+  (interactive)
+  (let ((buffer (get-buffer buffer-name)))
+    (if buffer
+        (buffer-size buffer)
+      0)))
+
+(defun buffer-file-name-base ()
+  "Return current buffers basename, sans extension."
+  (file-name-base (buffer-file-name (current-buffer)))
+  )
+
+
+;; teyjus-inferior-mode helper functions
+;;
+
+(defun teyjus-process ()
+  "Returns the process running in the *Teyjus* buffer"
+  (get-buffer-process (get-buffer "*Teyjus*")))
+
+(defun teyjus-process-stop ()
+  "Stop the process running in the *Teyjus* buffer, by sending it the 'stop.' goal."
+  (let* ((teyjus-buffer   (get-buffer "*Teyjus*")))
+    (comint-redirect-send-command-to-process "stop."
+                                             teyjus-buffer
+                                             (teyjus-process)
+                                             "Teyjus process ended.")))
+
+;; teyjus-inferior-mode Principle functions
+;;
+
+(defun teyjus-run (&optional module)
+  "Run `tjsim' in an inferior process.
+
+If `module' is supplied, it will try to load the corresponding .lp file
+into the simulator."
+  (interactive)
+  (let* ((proc-buffer-name  "*Teyjus*")
+         (proc-is-running   (comint-check-proc proc-buffer-name)))
+
+    ;; If the buffer has a running Teyjus process, stop it.
+    (when proc-is-running
+      (teyjus-process-stop)
+      ;; Wait for the process to return its exit code.
+      (accept-process-output (teyjus-process)))
+
+    ;; Start a new tjsim process in the "*Teyjus*" buffer
+    (apply 'make-comint-in-buffer "Teyjus" nil tjsim nil (list module))
+
+    ;; pop to the "*Teyjus*" buffer
+    (pop-to-buffer
+     (if (or proc-is-running
+             (not (derived-mode-p 'teyjus-inferior-mode))
+             (comint-check-proc (current-buffer)))
+         (get-buffer-create "*Teyjus*")
+       (current-buffer)))
+
+    ;; put the buffer into inferior mode
+    (teyjus-inferior-mode)))
+
+(defun teyjus-run-buffer ()
+  "Loads the current buffer module into tjsim."
+  (interactive)
+  ;; Add the directory holding buffer file to $TJPATH
+  (teyjus-path-add-current-buffer)
+  (teyjus-run (buffer-file-name-base)))
+
+(defun teyjus-link ()
+  "Link the current buffer module with tjlink."
+  (interactive)
+  ;; Add the directory holding buffer file to $TJPATH
+  (teyjus-path-add-current-buffer)
+  (let ((module (buffer-file-name-base)))
+    (make-comint "tjlink" tjlink nil module)))
+
+(defun teyjus-load-buffer ()
+  "Save, compile, link, and run the file being visited."
+  (interactive)
+  (let* ((module (buffer-file-name-base)))
+    ;; prompt to save buffer with `modulename.*'
+    ;; e.g., the modulename.mod and modulename.sig files.
+    (save-some-buffers nil (lambda ()
+                             (string= (buffer-file-name-base)
+                                      module)))
+    ;; Compile the module
+    (teyjus-compile)
+
+    ;; If compilation produces errors, terminate, leaving the
+    ;; *tjcc* buffer open so you can fix compilation errors.
+    (unless (accept-process-output (get-buffer-process (get-buffer "*tjcc*")))
+
+      ;; Otherwise, delete the *tjcc* window
+      (delete-windows-on "*tjcc*")
+
+      ;; And link the module
+      (teyjus-link)
+
+      ;; If tjlink fails
+      (if (accept-process-output (get-buffer-process (get-buffer "*tjlink*")))
+          ;; Then pop to the *tjlink* buffer
+          (pop-to-buffer "*tjlink*")
+          ;; Otherwise, load and run the module
+          (teyjus-run-buffer)))))
+
+(defun teyjus-inferior--initialize ()
+  "Helper function to initialize teyjus-inferior-mode."
+  (setq comint-process-echoes t))
+
+(define-derived-mode teyjus-inferior-mode comint-mode "Teyjus"
+  "`teyjus-inferior-mode' is a derived mode for running the `teyjus' simulator in emacs.
+
+- Use `teyjus-run-buffer' to start the simulator top-level as an inferior process.
+- Use `teyjus-load-buffer' to start the simulator after compiling, linking and
+loading the file being visited."
+
+  nil "Teyjus"
+  ;; Make the prompt read-only.
+  (setq comint-prompt-read-only t)
+  ;; Not sure what this does
+  (set (make-local-variable 'paragraph-separate) "\\'")
+  (set (make-local-variable 'font-lock-defaults) '(teyjus-font-lock-keywords t))
+  (set (make-local-variable 'paragraph-start) comint-prompt-regexp))
+
+(add-hook 'teyjus-inferior-mode-hook 'teyjus-inferior--initialize)


### PR DESCRIPTION
I have added basic support for a comint-derived inferior process. It is pretty basic, but provides the following functions:
- `teyjus-run`: Start an inferior process running `tjsim`. This is very handy, since it gives us a command line history (so dearly missed when using `tjsim` alone in the shell), and other nice emacs features. Given an argument, it will load the named module into the simulator (provided it can find a matching *.lp file via `TJPATH`).
- `teyjus-link`: Run `tjlink` on the files matching the basename of the buffer file.
- `teyjus-load-buffer`: Add the directory of the current buffer's file to the `TJPATH`, then save, compile, and link the module files indicated by the current buffer, and load it into a running inferior process.
- `teyjus-path-add-current-buffer` and `teyjus-path-remove-current-buffer`: Add or remove the current buffer file's directory to `TJPATH`. (This is, of course, only for the current emacs session, and does not interfere with the value of `$TJPATH` in the environment at large).

---

This is my first time submitting any sort of pull request, so please advise me if I can or should improve or fix anything, in terms of the code, the documentation, the information here, or my general approach.

This basic implementation of teyjus-inferior-mode still leaves plenty to be desired, and I'd be interested in refining it, and adding other helpful features if the need and desire arises.

![A Screenshot](http://i.imgur.com/vsOQrSy.png)
A screenshot: _Using the default key command `C-c C-f`, My `lists.mod` is loaded into an inferior process running `tjsim`, in the bottom right window. But — oops! — I accidentally used Prolog syntax! Having the command line history available makes it easy to change that into λProlog._
